### PR TITLE
Update CMakeLists.txt - fixed PDC_WIDE scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,10 @@ PUBLIC
 $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 $<INSTALL_INTERFACE:include>
 )
-target_compile_definitions(pdcurses PRIVATE
+target_compile_definitions(pdcurses
+PUBLIC
 $<$<BOOL:${PDCurses_WIDE}>:PDC_WIDE>
+PRIVATE
 $<$<BOOL:${PDCurses_UTF8}>:PDC_FORCE_UTF8>
 $<$<BOOL:${PDCurses_xaw3d}>:USE_XAW3D>
 $<$<BOOL:${PDCurses_nextaw}>:USE_NEXTAW>


### PR DESCRIPTION
The next define: `PDC_WIDE` is used in 'public interface' (in `curses.h`), so that need to be in `PUBLIC` scope!
Currently it in `PRIVATE` scope, so it passed during `pdcurses` files compiation, but not available for parent project.

For example, in the next case:

```cmake
set(PDCurses_WIDE ON CACHE BOOL "")
set(PDCurses_UTF8 ON CACHE BOOL "")

add_subdirectory(
  ${CMAKE_CURRENT_SOURCE_DIR}/third_party/PDCurses/PDCurses-cmake/
  tui__pdcurses
  EXCLUDE_FROM_ALL
)

add_executable(tui main.cpp)

target_link_libraries(tui
  PRIVATE
    pdcurses
)
``` 

even we set `PDCurses_WIDE` to `ON`, 'wide' types and functions (like `waddnwstr(...)`) not be available, since they available only under `ifdef` check:

https://github.com/scivision/PDCurses/blob/5c62af03e9a05e3a3ae8c8354c1234b772dcf4b0/curses.h#L1165-L1263

This PR fixes it :)

Also, @scivision thanks for your work over CMake build support!